### PR TITLE
Fix landing page backend module versioning, which was causing npm ins…

### DIFF
--- a/reset_backend.sh
+++ b/reset_backend.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 bash reset_postgres.sh
 cd services/lambda/sipuliton-backend
 bash start.sh

--- a/services/lambda/sipuliton-backend/landing/package-lock.json
+++ b/services/lambda/sipuliton-backend/landing/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "landing",
-  "version": "0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/services/lambda/sipuliton-backend/landing/package.json
+++ b/services/lambda/sipuliton-backend/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing",
-  "version": "0.1",
+  "version": "0.1.0",
   "description": "GET endpoint for landing page",
   "main": "src/landing.js",
   "repository": "",


### PR DESCRIPTION
pg now installed correctly when setting up back-end. Issue was in erroneous versioning of landing page back-end module itself in its package.json. Erroneous version was causing npm install to fail silently.